### PR TITLE
correction erreur de prefix pendant l'install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+include/connect.inc.php

--- a/install_mysql.php
+++ b/install_mysql.php
@@ -157,7 +157,7 @@ if ($etape == 4)
 			$query = preg_replace("/DROP TABLE IF EXISTS grr/","DROP TABLE IF EXISTS ".$table_prefix,$query);
 			$query = preg_replace("/CREATE TABLE grr/","CREATE TABLE ".$table_prefix,$query);
 			$query = preg_replace("/INSERT INTO grr/","INSERT INTO ".$table_prefix,$query);
-			var_dump($query);
+
 			if ($query != '')
 			{
 				$reg = mysqli_query($db, $query);

--- a/install_mysql.php
+++ b/install_mysql.php
@@ -135,6 +135,7 @@ if ($etape == 4)
 {
 	echo begin_page("Installation de GRR");
 	begin_html();
+	echo "<br /><h2>Quatrième étape : Création des tables de la base</h2>";
 	$db = mysqli_connect("$adresse_db", "$login_db", "$pass_db");
 	if ($choix_db == "new_grr")
 	{

--- a/install_mysql.php
+++ b/install_mysql.php
@@ -38,6 +38,7 @@ $pass_db = isset($_GET["pass_db"]) ? $_GET["pass_db"] : NULL;
 $choix_db = isset($_GET["choix_db"]) ? $_GET["choix_db"] : NULL;
 $table_new = isset($_GET["table_new"]) ? $_GET["table_new"] : NULL;
 $table_prefix = isset($_GET["table_prefix"]) ? $_GET["table_prefix"] : NULL;
+
 // Pour cette page uniquement, on désactive l'UTF8 et on impose l'ISO-8859-1
 $unicode_encoding = 1;
 $charset_html = "utf-8";
@@ -60,7 +61,16 @@ function mysqli_result($res, $row, $field = 0)
 }
 if (@file_exists($nom_fic))
 {
+	/* fix prefix missing */
+	if ( $table_prefix != NULL ) {
+		$table_prefix_from_user = $table_prefix;
+	} else {
+		$table_prefix_from_user = false;
+	}
 	require_once("include/connect.inc.php");
+	if ( empty($table_prefix) &&  $table_prefix_from_user !== false) {
+		$table_prefix = $table_prefix_from_user;
+	}
 	$db = @mysqli_connect("$dbHost", "$dbUser", "$dbPass", "$dbPort");
 	if ($db)
 	{
@@ -125,7 +135,6 @@ if ($etape == 4)
 {
 	echo begin_page("Installation de GRR");
 	begin_html();
-	echo "<br /><h2>Quatrième étape : Création des tables de la base</h2>";
 	$db = mysqli_connect("$adresse_db", "$login_db", "$pass_db");
 	if ($choix_db == "new_grr")
 	{
@@ -147,6 +156,7 @@ if ($etape == 4)
 			$query = preg_replace("/DROP TABLE IF EXISTS grr/","DROP TABLE IF EXISTS ".$table_prefix,$query);
 			$query = preg_replace("/CREATE TABLE grr/","CREATE TABLE ".$table_prefix,$query);
 			$query = preg_replace("/INSERT INTO grr/","INSERT INTO ".$table_prefix,$query);
+			var_dump($query);
 			if ($query != '')
 			{
 				$reg = mysqli_query($db, $query);


### PR DESCRIPTION
pendant l'installation, je n'avais jamais le prefix des tables.

Le fichier est écrit pendant l'étape 4, mais au début du fichier mysql_install, il y a le if (@file_exists($nom_fic)) et ensuite le include.

Comme le prefix est écrit à l'étape4, pendant l’exécution, il est vide, la variable $table_prefix est écrasée par celle du fichier qui est vide, et quand on arrive enfin à l'étape4, elle est vide.
J'ai juste ajouté un test avec une variable temporaire, on pourrait le faire plus propre, en refactorisant un peu l'install, mais j'ai préféré faire une correction qui impacte très peu le reste.
Je ne sais pas si vous avez des conventions, ou un truc déjà en cours concernant l'install.

Nicolas


