### PR TITLE
Update mrbs_sql.inc.php

### DIFF
--- a/include/mrbs_sql.inc.php
+++ b/include/mrbs_sql.inc.php
@@ -691,7 +691,7 @@ function mrbsGetEntryInfo($id)
 	$res = grr_sql_query($sql);
 	if (!$res)
 		return;
-	$ret = '';
+	$ret = array();
 	if (grr_sql_count($res) > 0)
 	{
 		$row = grr_sql_row($res, 0);


### PR DESCRIPTION
type of $ret variable in function mrbsGetEntryInfo is array, not string

On a CentOS 7 server with PHP v7.1.11 (at least), an error is raised when trying to delete an entry ("Illegal string offset" warning).

Bugfix : explicitly declare $ret as array (instead of $ret = '')