### PR TITLE
Explicitly declare entrys and entrys_return as arrays (PHP7 compatibility)

### DIFF
--- a/include/mrbs_sql.inc.php
+++ b/include/mrbs_sql.inc.php
@@ -522,8 +522,8 @@ function mrbsGetRepeatEntryList($time, $enddate, $rep_type, $rep_opt, $max_ittr,
 	$day   = date("d", $time);
 	$month = date("m", $time);
 	$year  = date("Y", $time);
-	$entrys = "";
-	$entrys_return = "";
+	$entrys = array();
+	$entrys_return = array();
 	$k = 0;
 	for($i = 0; $i < $max_ittr; $i++)
 	{


### PR DESCRIPTION
bugfix in function mrbsGetRepeatEntryList for PHP7

Source : https://site.devome.com/fr/kunena/signaler-un-probleme/20-compatiblite-grr-et-php7

Sur un serveur avec PHP7, la périodicité renvoit systématiquement une erreur et est inutilisable.