### PR TITLE
[MAJ] Calendrier et vue mois

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -26,6 +26,23 @@
 					changeYear: true,
 					showOn: "button",
 					showButtonPanel: true,
+					minDate: new Date(<?php echo $byear; ?>,<?php echo $bmonth; ?>,<?php echo $bday; ?>),
+					maxDate: new Date(<?php echo $eyear; ?>,<?php echo $emonth; ?>,<?php echo $eday; ?>),
+					onChangeMonthYear: function(year,month,instance) {
+						var mois = month;
+						var annee = year;
+							$(document).on("click",".ui-datepicker-next, .ui-datepicker-prev", function(){
+							var area = getQueryVariable("area");
+							var room = getQueryVariable("room");
+							var dir = location.href.replace(/[^/]*$/, '');
+							var date = $("#calendar").datepicker("getDate");
+								day  = date.getDate();
+							if(room){
+								self.location.replace(dir +"month.php?room="+ room +"&day="+ day +"&year="+ annee +"&month="+ mois);
+							} else {
+								self.location.replace(dir +"month_all.php?area="+ area +"&day="+ day +"&year="+ annee +"&month="+ mois);}
+							});
+					},
 					onSelect: function(dateText, inst) { 
 						var date = $(this).datepicker('getDate'),
 							day  = date.getDate(),  

--- a/menu_gauche.php
+++ b/menu_gauche.php
@@ -40,6 +40,14 @@ if ($_GET['pview'] != 1)
     else $pageTout = $pageSimple."_all.php";
     // $pageSimple .= '.php';
 	
+	//récupération des valeurs 
+	$bday = strftime('%d', Settings::get('begin_bookings'));
+    $bmonth = strftime('%m', Settings::get('begin_bookings'));
+	$byear = strftime('%Y', Settings::get('begin_bookings'));
+	
+	$eday = strftime('%d', Settings::get('end_bookings'));
+    $emonth = strftime('%m', Settings::get('end_bookings'));
+	$eyear = strftime('%Y', Settings::get('end_bookings'));
     // Calendrier en JQuery/Ajax avec gestion des langues via le navigateur
 	echo '<div id="datepicker-container">';
 	echo '<div id="datepicker-center">';

--- a/menu_gauche2.php
+++ b/menu_gauche2.php
@@ -59,6 +59,14 @@ if ($_GET['pview'] != 1)
     else $pageTout = $pageSimple."_all.php";
     // $pageSimple .= '.php';
 	
+	//récupération des valeurs 
+	$bday = strftime('%d', Settings::get('begin_bookings'));
+    $bmonth = strftime('%m', Settings::get('begin_bookings'));
+	$byear = strftime('%Y', Settings::get('begin_bookings'));
+	
+	$eday = strftime('%d', Settings::get('end_bookings'));
+    $emonth = strftime('%m', Settings::get('end_bookings'));
+	$eyear = strftime('%Y', Settings::get('end_bookings'));
     // Calendrier en JQuery/Ajax avec gestion des langues via le navigateur
 	echo '<div id="datepicker-container">';
 	echo '<div id="datepicker-center">';


### PR DESCRIPTION
Bonjour,

Suite à la mise en production de notre calendrier nos utilisateurs nous ont remontés qu'ils ne pouvaient pas accéder facilement à la vue month. Nous avons donc modifié le calendrier pour que les flèches mois 'précedent'/'suivant' actualisent l'affichage du planning en month ou month_all selon la sélection d'une ressource.

Nous avons également fait en sorte que le calendrier soit borné par les dates de début et fin de réservation saisies dans l'interface administrateur de GRR.