### PR TITLE
Modification : Integration de la langue pour le calendrier JS

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -15,7 +15,12 @@
 		
 		$(document).ready(function() {  
   
-            var userLang = navigator.language || navigator.userLanguage;  
+             var lang = "<?php echo $langue;?>";
+		if (lang == "fr"){
+            var userLang = "fr";
+		} else {
+			var userLang = "en";
+		}    
   
             var options = $.extend({},   
                 $.datepicker.regional[userLang], {  

--- a/day.php
+++ b/day.php
@@ -172,6 +172,7 @@ if (!$ressources)
 	fatal_error(0, grr_sql_error());
 
 // code HTML
+$langue=$_SESSION['default_language'];
 echo '<!DOCTYPE html>'.PHP_EOL;
 echo '<html lang="fr">'.PHP_EOL;
 // section <head>


### PR DESCRIPTION
Bonjour ,
J'ai supprimer directement le choix de langue depuis le navigateur car cela nous posait quelques problèmes au niveau du calendrier JS dans d'autres navigateur (chrome) donc j'ai pris la langue que l'on sélectionne en haut à droite de la page pour que ça change aussi la langue du calendrier .
Calendrier en français:
![Capture d’écran de 2019-06-20 11-19-01](https://user-images.githubusercontent.com/50909713/59841238-3b200180-9354-11e9-9262-a4629960563e.png)
Calendrier en anglais:
![Capture d’écran de 2019-06-20 11-19-16](https://user-images.githubusercontent.com/50909713/59841286-4ffc9500-9354-11e9-9c42-8ad7ffc67a3a.png)

