### PR TITLE
Duplicate key when synchronising group

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -2006,7 +2006,8 @@ function synchro_groupe($idGroupe, $action)
 		{
 			for ($i = 0; ($row2 = grr_sql_row($res2, $i)); $i++)
 			{
-				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_site jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_site = $row2[0] AND idgroupes = $idGroupe";
+				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_site jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_site = $row2[0] AND jg.idgroupes = $idGroupe";
+				//var_dump($sql3);die;
 				$res3 = grr_sql_query($sql3);
 
 				for ($i = 0; ($row3 = grr_sql_row($res3, $i)); $i++)
@@ -2030,7 +2031,7 @@ function synchro_groupe($idGroupe, $action)
 		{
 			for ($i = 0; ($row2 = grr_sql_row($res2, $i)); $i++)
 			{
-				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_area jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_area = $row2[0] AND idgroupes = $idGroupe";
+				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_area jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_area = $row2[0] AND jg.idgroupes = $idGroupe";
 				$res3 = grr_sql_query($sql3);
 
 				for ($i = 0; ($row3 = grr_sql_row($res3, $i)); $i++)

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -2006,7 +2006,7 @@ function synchro_groupe($idGroupe, $action)
 		{
 			for ($i = 0; ($row2 = grr_sql_row($res2, $i)); $i++)
 			{
-				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_site jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_site = $row2[0]";
+				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_site jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_site = $row2[0] AND idgroupes = $idGroupe";
 				$res3 = grr_sql_query($sql3);
 
 				for ($i = 0; ($row3 = grr_sql_row($res3, $i)); $i++)
@@ -2030,7 +2030,7 @@ function synchro_groupe($idGroupe, $action)
 		{
 			for ($i = 0; ($row2 = grr_sql_row($res2, $i)); $i++)
 			{
-				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_area jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_area = $row2[0]";
+				$sql3 = "SELECT ug.login FROM ".TABLE_PREFIX."_j_group_area jg LEFT JOIN ".TABLE_PREFIX."_utilisateurs_groupes ug ON jg.idgroupes = ug.idgroupes WHERE jg.id_area = $row2[0] AND idgroupes = $idGroupe";
 				$res3 = grr_sql_query($sql3);
 
 				for ($i = 0; ($row3 = grr_sql_row($res3, $i)); $i++)


### PR DESCRIPTION
In certain cironstancies a duplicate key error occurs when synchronising groups