### PR TITLE
correctif: bénéficiaire extérieurs qui ne s'enregistrent pas

### DIFF
--- a/reservation/controleurs/editentreetrt.php
+++ b/reservation/controleurs/editentreetrt.php
@@ -150,8 +150,6 @@ try {
         }
         $beneficiaire = "";
     }
-    else
-        $beneficiaire_ext = "";
 
     if ((!isset($rooms[0])||(intval($rooms[0])==0))){
         $d['err_type']="choose_a_room";


### PR DESCRIPTION
Je viens de corriger le bug des bénéficiaires extérieurs qui ne s'enregistraient pas dans al DB.
A partir du tag v4.4.2.

Cordialement