### PR TITLE
Ajout bouton submit pour les moderateurs

### DIFF
--- a/reservation/templates/vuereservation.twig
+++ b/reservation/templates/vuereservation.twig
@@ -344,7 +344,7 @@
             <input type="hidden" name="month" value="{{d.month}}" />
             <input type="hidden" name="year" value="{{d.year}}" />
             <input type="hidden" name="back" value="{{d.back}}" />
-            {% if d.choixEmprunter and d.clefCourrier == 1 %}
+            {% if d.choixEmprunter and d.clefCourrier == 1 or d.choixModeration %}
                 <br /><div style="text-align:center;"><input class="btn btn-primary" type="submit" name="commit" value="{{trad.save}}" /></div>
             {% endif %}
         </form>


### PR DESCRIPTION
Suite au commit 8eb5ae9 (issue #577), le bouton enregistrer n'apparait plus pour la modération des ressources. Ce fix le fait ré-apparaitre.
